### PR TITLE
ci: switch to monthly PHP Dependabot dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,9 +12,7 @@ updates:
   - package-ecosystem: composer
     directory: /backend
     schedule:
-      interval: weekly
-      day: wednesday
-      time: '06:30'
+      interval: monthly
     commit-message:
       prefix: misc
     labels:


### PR DESCRIPTION
| Q            | A
| ------------ | ---
| Bug fix?     | no
| New feature? | no
| Issues       | /
| License      | MIT

Switches to monthly Dependabot dependency updates for the PHP/Symfony backend in preparation for a more active development phase.
