### PR TITLE
feature(#56): add UUID entity ids

### DIFF
--- a/backend/composer.json
+++ b/backend/composer.json
@@ -26,6 +26,7 @@
         "symfony/runtime": "6.3.*",
         "symfony/serializer": "6.3.*",
         "symfony/twig-bundle": "6.3.*",
+        "symfony/uid": "6.3.*",
         "symfony/validator": "6.3.*",
         "symfony/yaml": "6.3.*"
     },

--- a/backend/composer.lock
+++ b/backend/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "94d66cfd283f1c4885892ba7e5c27b12",
+    "content-hash": "72c25e0b83e1d1626596dd547fa872e8",
     "packages": [
         {
             "name": "beberlei/assert",
@@ -4919,6 +4919,88 @@
             "time": "2023-08-16T06:22:46+00:00"
         },
         {
+            "name": "symfony/polyfill-uuid",
+            "version": "v1.28.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-uuid.git",
+                "reference": "9c44518a5aff8da565c8a55dbe85d2769e6f630e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-uuid/zipball/9c44518a5aff8da565c8a55dbe85d2769e6f630e",
+                "reference": "9c44518a5aff8da565c8a55dbe85d2769e6f630e",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1"
+            },
+            "provide": {
+                "ext-uuid": "*"
+            },
+            "suggest": {
+                "ext-uuid": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "1.28-dev"
+                },
+                "thanks": {
+                    "name": "symfony/polyfill",
+                    "url": "https://github.com/symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Uuid\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Grégoire Pineau",
+                    "email": "lyrixx@lyrixx.info"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for uuid functions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "polyfill",
+                "portable",
+                "uuid"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-uuid/tree/v1.28.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2023-01-26T09:26:14+00:00"
+        },
+        {
             "name": "symfony/property-access",
             "version": "v6.3.2",
             "source": {
@@ -5818,6 +5900,80 @@
             "homepage": "https://symfony.com",
             "support": {
                 "source": "https://github.com/symfony/twig-bundle/tree/v6.3.8"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2023-10-31T08:07:48+00:00"
+        },
+        {
+            "name": "symfony/uid",
+            "version": "v6.3.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/uid.git",
+                "reference": "819fa5ac210fb7ddda4752b91a82f50be7493dd9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/uid/zipball/819fa5ac210fb7ddda4752b91a82f50be7493dd9",
+                "reference": "819fa5ac210fb7ddda4752b91a82f50be7493dd9",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1",
+                "symfony/polyfill-uuid": "^1.15"
+            },
+            "require-dev": {
+                "symfony/console": "^5.4|^6.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Uid\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Grégoire Pineau",
+                    "email": "lyrixx@lyrixx.info"
+                },
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Provides an object-oriented API to generate and represent UIDs",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "UID",
+                "ulid",
+                "uuid"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/uid/tree/v6.3.8"
             },
             "funding": [
                 {

--- a/backend/config/packages/uid.yaml
+++ b/backend/config/packages/uid.yaml
@@ -1,0 +1,4 @@
+framework:
+    uid:
+        default_uuid_version: 7
+        time_based_uuid_version: 7

--- a/backend/src/Framework/Domain/Id/UuidEntityId.php
+++ b/backend/src/Framework/Domain/Id/UuidEntityId.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Framework\Domain\Id;
+
+use Fusonic\DDDExtensions\Domain\Model\EntityId;
+use Fusonic\DDDExtensions\Domain\Model\ValueObject;
+use Symfony\Component\Uid\Uuid;
+
+abstract class UuidEntityId extends EntityId
+{
+    private readonly Uuid $id;
+
+    public function __construct(Uuid $id = null)
+    {
+        $this->id = $id ?? Uuid::v7();
+    }
+
+    public function __toString(): string
+    {
+        return (string) $this->id;
+    }
+
+    public function isDefined(): bool
+    {
+        return true;
+    }
+
+    public function getValue(): Uuid
+    {
+        return $this->id;
+    }
+
+    public function equals(ValueObject $object): bool
+    {
+        return $object instanceof self
+            && $this->id->equals($object->id);
+    }
+}

--- a/backend/src/Framework/Infrastructure/Normalizer/UuidEntityIdNormalizer.php
+++ b/backend/src/Framework/Infrastructure/Normalizer/UuidEntityIdNormalizer.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Framework\Infrastructure\Normalizer;
+
+use Framework\Domain\Id\UuidEntityId;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+use Symfony\Component\Uid\Uuid;
+
+final readonly class UuidEntityIdNormalizer implements NormalizerInterface, DenormalizerInterface
+{
+    public function normalize(mixed $object, string $format = null, array $context = []): string
+    {
+        return $object->getValue();
+    }
+
+    /**
+     * @param array<mixed> $context
+     */
+    public function supportsNormalization(mixed $data, string $format = null, array $context = []): bool
+    {
+        return $data instanceof UuidEntityId;
+    }
+
+    public function denormalize(mixed $data, string $type, string $format = null, array $context = []): UuidEntityId
+    {
+        /** @var UuidEntityId $id */
+        $id = new $type(Uuid::fromString($data));
+
+        return $id;
+    }
+
+    /**
+     * @param array<mixed> $context
+     */
+    public function supportsDenormalization(mixed $data, string $type, string $format = null, array $context = []): bool
+    {
+        return \is_string($data) && Uuid::isValid($data) && is_a($type, UuidEntityId::class, true);
+    }
+
+    /**
+     * @return array<class-string, bool>
+     */
+    public function getSupportedTypes(?string $format): array
+    {
+        return [
+            UuidEntityId::class => false,
+        ];
+    }
+}

--- a/backend/src/Framework/Infrastructure/Types/UuidEntityIdType.php
+++ b/backend/src/Framework/Infrastructure/Types/UuidEntityIdType.php
@@ -1,0 +1,122 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Framework\Infrastructure\Types;
+
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Types\ConversionException;
+use Doctrine\DBAL\Types\Type;
+use Framework\Domain\Id\UuidEntityId;
+use Symfony\Bridge\Doctrine\Types\AbstractUidType;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * The code of this class has been copied over from {@see AbstractUidType} and was adjusted to fit the needs of the
+ * custom {@see UuidEntityId} implementation, also based on the {@see Uuid} class.
+ */
+abstract class UuidEntityIdType extends Type
+{
+    /**
+     * @return class-string
+     */
+    abstract protected function getTypeClass(): string;
+
+    public function getSQLDeclaration(array $column, AbstractPlatform $platform): string
+    {
+        if ($this->hasNativeGuidType($platform)) {
+            return $platform->getGuidTypeDeclarationSQL($column);
+        }
+
+        return $platform->getBinaryTypeDeclarationSQL([
+            'length' => 16,
+            'fixed' => true,
+        ]);
+    }
+
+    public function convertToDatabaseValue(mixed $value, AbstractPlatform $platform): string
+    {
+        if ($value instanceof UuidEntityId) {
+            return $this->hasNativeGuidType($platform) ? $value->getValue()->toRfc4122() : $value->getValue()->toBinary();
+        }
+
+        if (!\is_string($value)) {
+            $this->throwInvalidType($value);
+        }
+
+        try {
+            $uuid = Uuid::fromString($value);
+
+            $typeClass = $this->getTypeClass();
+            /** @var UuidEntityId $object */
+            $object = new $typeClass($uuid);
+
+            return (string) $object;
+        } catch (\InvalidArgumentException $e) {
+            $this->throwValueNotConvertible($value, $e);
+        }
+    }
+
+    public function convertToPHPValue(mixed $value, AbstractPlatform $platform): UuidEntityId
+    {
+        $typeClass = $this->getTypeClass();
+
+        if ($value instanceof Uuid || null === $value) {
+            /** @var UuidEntityId $object */
+            $object = new $typeClass($value);
+
+            return $object;
+        }
+
+        if (!\is_string($value)) {
+            $this->throwInvalidType($value);
+        }
+
+        try {
+            $uuid = Uuid::fromString($value);
+
+            /** @var UuidEntityId $object */
+            $object = new $typeClass($uuid);
+
+            return $object;
+        } catch (\InvalidArgumentException $e) {
+            $this->throwValueNotConvertible($value, $e);
+        }
+    }
+
+    public function requiresSQLCommentHint(AbstractPlatform $platform): bool
+    {
+        // Add comment to prevent Doctrine from always detecting changes that need to be applied to the schema.
+        return true;
+    }
+
+    private function hasNativeGuidType(AbstractPlatform $platform): bool
+    {
+        // Compatibility with DBAL < 3.4
+        // @phpstan-ignore-next-line
+        $method = method_exists($platform, 'getStringTypeDeclarationSQL')
+            ? 'getStringTypeDeclarationSQL'
+            : 'getVarcharTypeDeclarationSQL';
+
+        // @phpstan-ignore-next-line
+        return $platform->getGuidTypeDeclarationSQL([]) !== $platform->$method(['fixed' => true, 'length' => 36]);
+    }
+
+    private function throwInvalidType(mixed $value): never
+    {
+        throw ConversionException::conversionFailedInvalidType(
+            value: $value,
+            toType: self::getTypeRegistry()->lookupName($this),
+            possibleTypes: ['null', 'string', Uuid::class]
+        );
+    }
+
+    private function throwValueNotConvertible(mixed $value, \Throwable $previous): never
+    {
+        throw ConversionException::conversionFailed(
+            value: $value,
+            toType: self::getTypeRegistry()->lookupName($this),
+            previous: $previous
+        );
+    }
+}

--- a/backend/src/Framework/Port/Http/UuidEntityIdModelDescriber.php
+++ b/backend/src/Framework/Port/Http/UuidEntityIdModelDescriber.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Framework\Port\Http;
+
+use Framework\Domain\Id\UuidEntityId;
+use Nelmio\ApiDocBundle\Model\Model;
+use Nelmio\ApiDocBundle\ModelDescriber\ModelDescriberInterface;
+use OpenApi\Annotations\Schema;
+use Symfony\Component\PropertyInfo\Type;
+
+final readonly class UuidEntityIdModelDescriber implements ModelDescriberInterface
+{
+    public function describe(Model $model, Schema $schema): void
+    {
+        $type = $model->getType();
+        /** @var class-string|null $className */
+        $className = $type->getClassName();
+
+        if (null !== $className && is_a($className, UuidEntityId::class, true)) {
+            $schema->type = 'string';
+            $schema->format = 'uuid';
+        }
+    }
+
+    public function supports(Model $model): bool
+    {
+        $type = $model->getType();
+        /** @var class-string|null $className */
+        $className = $type->getClassName();
+
+        return Type::BUILTIN_TYPE_OBJECT === $type->getBuiltinType()
+            && null !== $className
+            && is_a($className, UuidEntityId::class, true);
+    }
+}

--- a/backend/src/Framework/Port/Http/UuidPropertyDescriber.php
+++ b/backend/src/Framework/Port/Http/UuidPropertyDescriber.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Framework\Port\Http;
+
+use Nelmio\ApiDocBundle\PropertyDescriber\NullablePropertyTrait;
+use Nelmio\ApiDocBundle\PropertyDescriber\PropertyDescriberInterface;
+use OpenApi\Annotations\Schema;
+use Symfony\Component\PropertyInfo\Type;
+use Symfony\Component\Uid\Uuid;
+
+final readonly class UuidPropertyDescriber implements PropertyDescriberInterface
+{
+    use NullablePropertyTrait;
+
+    /**
+     * @param array<mixed>|null $groups
+     */
+    public function describe(array $types, Schema $property, array $groups = null): void
+    {
+        $property->type = 'string';
+        $this->setNullableProperty($types[0], $property);
+    }
+
+    public function supports(array $types): bool
+    {
+        return 1 === \count($types)
+            && is_a($types[0], Type::class)
+            && null !== $types[0]->getClassName()
+            && is_a($types[0]->getClassName(), Uuid::class, true);
+    }
+}

--- a/backend/symfony.lock
+++ b/backend/symfony.lock
@@ -224,6 +224,18 @@
             "templates/base.html.twig"
         ]
     },
+    "symfony/uid": {
+        "version": "6.3",
+        "recipe": {
+            "repo": "github.com/symfony/recipes",
+            "branch": "main",
+            "version": "6.2",
+            "ref": "d294ad4add3e15d7eb1bae0221588ca89b38e558"
+        },
+        "files": [
+            "config/packages/uid.yaml"
+        ]
+    },
     "symfony/validator": {
         "version": "6.3",
         "recipe": {


### PR DESCRIPTION
| Q            | A
| ------------ | ---
| Bug fix?     | no
| New feature? | yes
| Issues       | Close #56
| License      | MIT

Adds the `symfony/uid` component and uses the provided UUID v7 implementation to create a base `UuidEntityId` that can later on be used as a base class for entity-specific id classes.
