### PR TITLE
revert(#4): re-enable PR lint workflow runs on synchronization

### DIFF
--- a/.github/workflows/pr_lint.yml
+++ b/.github/workflows/pr_lint.yml
@@ -6,6 +6,7 @@ on:
       - opened
       - edited
       - reopened
+      - synchronize
 
 jobs:
   lint-pr:


### PR DESCRIPTION
| Q            | A
| ------------ | ---
| Bug fix?     | yes
| New feature? | no
| Issues       | Related to #4
| License      | MIT

Reverts commit 095388b that removed the `synchronize` event causing the workflow to run. Without it, the workflow's status is reset after a new commit is pushed to the PR, thus preventing (auto) merging.
